### PR TITLE
fix(docs):  Fix module import error by setting PYTHONPATH in docker-compose

### DIFF
--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - UPSTREAM_REPO
       - MODE
       - PATCH_VERSION
+      - PYTHONPATH=/main
     volumes:
       - ../docs:/main/docs
       - ../${PACKAGE}:/main/${PACKAGE}


### PR DESCRIPTION
Add PYTHONPATH to fix mkdocstrings import error.  This commit is a fix for building the docs file in GHA and doesn't change the content of the project.



